### PR TITLE
Issue34 dam 110 investigate regex replace filter bug

### DIFF
--- a/tasks/install-oswbs.yml
+++ b/tasks/install-oswbs.yml
@@ -6,10 +6,6 @@
   register: osbws_ora_file
   become: true
 
-# - name: (main/install-osbws) Set fact instance_profile
-#   set_fact:
-#     instance_profile: "{{ ansible_ec2_iam_instance_profile_role | regex_replace('_type') }}"
-
 - name: (main/install-osbws) Set fact instance_profile
   set_fact:
     instance_profile: "{{ ansible_ec2_iam_info_instanceprofilearn.split('/')[1] }}"

--- a/tasks/install-oswbs.yml
+++ b/tasks/install-oswbs.yml
@@ -6,6 +6,14 @@
   register: osbws_ora_file
   become: true
 
+- name: (main/install-osbws) Set fact instance_profile
+  set_fact:
+    instance_profile: "{{ ansible_ec2_iam_instance_profile_role | regex_replace('_type') }}"
+
+- name: (main/install-osbws) debug instance_profile
+  debug:
+    msg: "{{ instance_profile }}"
+
 - name: (main/install-osbws) Copy argfile file template
   template:
     src: "{{ role_path }}/templates/osbws-argfile.j2"
@@ -14,7 +22,7 @@
     group: "{{ service_user_group }}"
   register: argfile
 
-- name: debug
+- name: (main/install-osbws) debug argfile
   debug:
     msg: "{{ argfile }}"
 

--- a/tasks/install-oswbs.yml
+++ b/tasks/install-oswbs.yml
@@ -6,9 +6,13 @@
   register: osbws_ora_file
   become: true
 
+# - name: (main/install-osbws) Set fact instance_profile
+#   set_fact:
+#     instance_profile: "{{ ansible_ec2_iam_instance_profile_role | regex_replace('_type') }}"
+
 - name: (main/install-osbws) Set fact instance_profile
   set_fact:
-    instance_profile: "{{ ansible_ec2_iam_instance_profile_role | regex_replace('_type') }}"
+    instance_profile: "{{ ansible_ec2_iam_info_instanceprofilearn.split('/')[1] }}"
 
 - name: (main/install-osbws) debug instance_profile
   debug:

--- a/tasks/install-oswbs.yml
+++ b/tasks/install-oswbs.yml
@@ -1,5 +1,11 @@
 ---
 
+- name: (main/install-osbws) validate oracle_osbws_ora_file written
+  stat:
+    path: "{{ oracle_osbws_ora_file }}"
+  register: osbws_ora_file
+  become: true
+
 - name: (main/install-osbws) Copy argfile file template
   template:
     src: "{{ role_path }}/templates/osbws-argfile.j2"
@@ -21,7 +27,7 @@
   become_user: "{{ service_user_name }}"
   register: install
   failed_when: install.rc !=0
-  when: argfile.changed
+  when: argfile.changed or osbws_ora_file.stat.exists == false
 
 - name: (main/install-osbws) Extract Oracle DB backups S3 bucket name from arn
   set_fact:

--- a/templates/osbws-argfile.j2
+++ b/templates/osbws-argfile.j2
@@ -1,4 +1,4 @@
--IAMRole {{ ansible_ec2_iam_instance_profile_role | regex_replace('_type') }}
+-IAMRole {{ instance_profile }}
 -walletDir {{ oracle_database_oracle_home }}/dbs/osbws_wallet
 -libDir {{ oracle_database_oracle_home }}/lib
 -location {{ ansible_ec2_instance_identity_document_region }}


### PR DESCRIPTION
Closes #34 

AWS return different values in the "ansible_ec2_iam_instance_profile_role" ansible ec2 instance fact. One server had "_type" vs "_token" suffixed to the role name - breaking the original filter.

Updated to retrieve role name from the arn.

Tested on both sandpit and auto-test servers.